### PR TITLE
Keep the script from trying to compare Issue objects

### DIFF
--- a/upkeep.py
+++ b/upkeep.py
@@ -176,7 +176,10 @@ if __name__ == '__main__':
     issues = issues[:min(10 + args.workdays_ahead, issues.totalCount)]
     date_issue_pairs = [(issue_title_to_date(issue.title), issue) for issue in issues]
     # Filter issues that are not scrum entries
-    date_issue_pairs = sorted((date, issue) for date, issue in date_issue_pairs if date)
+    filtered_date_issue_pairs = [(date, issue) for date, issue in date_issue_pairs if date]
+
+    # Issue objects are not comparable, so we need to sort by date only
+    date_issue_pairs = sorted(filtered_date_issue_pairs, key=lambda x: x[0])
 
     # Detect previous issue for creation of the first upcoming issue
     previous_issue = None


### PR DESCRIPTION
The script for producing new issues sorts the current issue titles' dates and looks for the most recent one. Due to the way the data structures were set up, if the date was not unique, it would then try to sort issues by Issue objects. Because Issue objects don't have a comparison operator, the bot ran fine for years until a duplicate date popped up somewhere and broke everything.

This PR fixes that issue